### PR TITLE
feat: Auto format attributes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ it may need.
     my_formats = {
         'jenkins_job_name': '{project}-{repo}-master',
         'app': 'app-{project}{repo}',
+        'custom': '{project}*.*{repo}',
     }
 
     info = Generator(project, repo, 'dev', formats=my_formats)
@@ -28,6 +29,9 @@ it may need.
 
     info.app_name()
     > app-gogoairtest
+
+    info.custom
+    > gogoair*.*test
 
 
 Classes

--- a/src/gogoutils/generator.py
+++ b/src/gogoutils/generator.py
@@ -50,6 +50,10 @@ class Generator(object):
         }
         self.data.update(self.format.get_formats())
 
+    def __getattr__(self, name):
+        """Return formatted string from :attr:`format`."""
+        return self.data[name].format(**self.data)
+
     @property
     def app(self):
         """Return the generated app name."""

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -322,3 +322,59 @@ def test_apigateway_domain():
             PROJECTS[project]['env'],
         )
         assert domain == g.apigateway()['domain']
+
+
+@pytest.mark.parametrize('formats, expected', [
+    (
+        {
+            'test': '{project}|{repo}'
+        },
+        'gogoair|test',
+    ),
+    (
+        {
+            'test': '{project}|{repo}-{special}',
+            'special': 'pretty',
+        },
+        'gogoair|test-pretty',
+    ),
+])
+def test_autoformat_attr(formats, expected):
+    """Validate unknown attributes are formatted."""
+    p = PROJECTS['repo1']
+
+    g = Generator(
+        p['project'],
+        p['repo'],
+        env=p['env'],
+        region=p['region'],
+        formats=formats,
+    )
+
+    assert g.test == expected
+
+
+class CustomFormatting(str):
+    """Custom string formatter."""
+
+    def format(self, *args, **kwargs):
+        """Override default format method."""
+        custom = kwargs['repo'].replace(' ', '--').upper()
+        return super(CustomFormatting, self).format(*args, custom=custom, **kwargs)
+
+
+def test_format_method():
+    """Objects with :meth:`format` should string format correctly."""
+    formats = {
+        'test': CustomFormatting('{region}-{custom}+{project}'),
+    }
+
+    g = Generator(
+        'project',
+        'has an apple',
+        env='home',
+        region='Uruguay',
+        formats=formats,
+    )
+
+    assert g.test == 'uruguay-HAS--AN--APPLE+project'


### PR DESCRIPTION
For people who want to reference custom keys in `formats`, this facilitates dynamic formatting on accessing attributes instead of relying on an existing Method or Property.
```python
>>> import gogoutils
>>> formats = {
...     'organization': 'alpha',
...     'team': '{organization}-team',
... }
>>> g = gogoutils.Generator('p', 'r', formats=formats)
>>> print(g.team)
alpha-team
```
We can also get started testing with custom Objects that provide a `format` Method for those who need to do a lot of processing.