### PR TITLE
Feature: Add security group and elb names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ These are the services you can customize the formats along with their default fo
     s3_archaius_name,archaius-{env}/{project}/{repo}{project}/,S3 full path for archaius
     s3_bucket,archaius-{env},S3 archaius bucket name
     s3_bucket_path,{project}/{repo}{project},S3 path for app (within s3_bucket)
+    security_group_app,{repo}{project},Security Group name
     shared_s3_app_bucket,common-{project},S3 bucket name for shared buckets
     shared_s3_app_region_bucket,common-{project}-{region},S3 bucket name for shared buckets with region
 

--- a/README.rst
+++ b/README.rst
@@ -76,9 +76,9 @@ These are the services you can customize the formats along with their default fo
     dns_elb,{repo}.{project}.{env}.{domain},FQDN of DNS ELB
     dns_instance,{repo}{project}-xx.{env}.{domain}, FQDN of instances
     domain,example.com,Domain
+    git_repo,{raw_project}/{raw_repo},Apps git repo
     git_repo_configs,{raw_project}/{raw_repo}-config,Config git repo
     git_repo_qe,{raw_project}/{raw_repo}-qa,QA's git repo
-    git_repo,{raw_project}/{raw_repo},Apps git repo
     iam_base,{project}_{repo},IAM profile base
     iam_group,{project},IAM group name
     iam_lambda_role,{project}_{repo}_lambda_role,Lambda IAM role name
@@ -89,11 +89,11 @@ These are the services you can customize the formats along with their default fo
     jenkins_job_name,{project}_{repo},Jenkins job name
     s3_app_bucket,{project}-{repo},Application specific S3 bucket name
     s3_app_region_bucket,{project}-{repo}-{region},Application specific S3 bucket name with region
+    s3_archaius_name,archaius-{env}/{project}/{repo}{project}/,S3 full path for archaius
+    s3_bucket,archaius-{env},S3 archaius bucket name
+    s3_bucket_path,{project}/{repo}{project},S3 path for app (within s3_bucket)
     shared_s3_app_bucket,common-{project},S3 bucket name for shared buckets
     shared_s3_app_region_bucket,common-{project}-{region},S3 bucket name for shared buckets with region
-    s3_archaius_name,archaius-{env}/{project}/{repo}{project}/,S3 full path for archaius
-    s3_bucket_path,{project}/{repo}{project},S3 path for app (within s3_bucket)
-    s3_bucket,archaius-{env},S3 archaius bucket name
 
 
 Contributions

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,7 @@ These are the services you can customize the formats along with their default fo
     dns_elb,{repo}.{project}.{env}.{domain},FQDN of DNS ELB
     dns_instance,{repo}{project}-xx.{env}.{domain}, FQDN of instances
     domain,example.com,Domain
+    elb_app,{repo}{project},ELB Name
     git_repo,{raw_project}/{raw_repo},Apps git repo
     git_repo_configs,{raw_project}/{raw_repo}-config,Config git repo
     git_repo_qe,{raw_project}/{raw_repo}-qa,QA's git repo

--- a/src/gogoutils/formats.py
+++ b/src/gogoutils/formats.py
@@ -28,6 +28,7 @@ DEFAULT_FORMAT = {
     'dns_instance': '{repo}{project}-xx.{env}.{domain}',
     'dns_region': '{repo}.{project}.{region}.{env}.{domain}',
     'domain': 'example.com',
+    'elb_app': '{repo}{project}',
     'git_repo': '{raw_project}/{raw_repo}',
     'git_repo_configs': '{raw_project}/{raw_repo}-config',
     'git_repo_qe': '{raw_project}/{raw_repo}-qa',

--- a/src/gogoutils/formats.py
+++ b/src/gogoutils/formats.py
@@ -22,15 +22,15 @@ except ImportError:
 DEFAULT_FORMAT = {
     'apigateway_domain': 'api.{env}.{domain}',
     'app': '{repo}{project}',
-    'dns_elb_region': '{repo}.{project}.{region}.{env}.{domain}',
     'dns_elb': '{repo}.{project}.{env}.{domain}',
+    'dns_elb_region': '{repo}.{project}.{region}.{env}.{domain}',
     'dns_global': '{repo}.{project}.{env}.{domain}',
-    'dns_region': '{repo}.{project}.{region}.{env}.{domain}',
     'dns_instance': '{repo}{project}-xx.{env}.{domain}',
+    'dns_region': '{repo}.{project}.{region}.{env}.{domain}',
     'domain': 'example.com',
+    'git_repo': '{raw_project}/{raw_repo}',
     'git_repo_configs': '{raw_project}/{raw_repo}-config',
     'git_repo_qe': '{raw_project}/{raw_repo}-qa',
-    'git_repo': '{raw_project}/{raw_repo}',
     'iam_base': '{project}_{repo}',
     'iam_group': '{project}',
     'iam_lambda_role': '{project}_{repo}_role',
@@ -41,11 +41,11 @@ DEFAULT_FORMAT = {
     'jenkins_job_name': '{project}_{repo}',
     's3_app_bucket': '{project}-{repo}',
     's3_app_region_bucket': '{project}-{repo}-{region}',
+    's3_archaius_name': 'archaius-{env}/{project}/{repo}{project}/',
+    's3_bucket': 'archaius-{env}',
+    's3_bucket_path': '{project}/{repo}{project}',
     'shared_s3_app_bucket': 'common-{project}',
     'shared_s3_app_region_bucket': 'common-{project}-{region}',
-    's3_archaius_name': 'archaius-{env}/{project}/{repo}{project}/',
-    's3_bucket_path': '{project}/{repo}{project}',
-    's3_bucket': 'archaius-{env}',
 }
 
 

--- a/src/gogoutils/formats.py
+++ b/src/gogoutils/formats.py
@@ -44,6 +44,7 @@ DEFAULT_FORMAT = {
     's3_archaius_name': 'archaius-{env}/{project}/{repo}{project}/',
     's3_bucket': 'archaius-{env}',
     's3_bucket_path': '{project}/{repo}{project}',
+    'security_group_app': '{repo}{project}',
     'shared_s3_app_bucket': 'common-{project}',
     'shared_s3_app_region_bucket': 'common-{project}-{region}',
 }


### PR DESCRIPTION
This adds security group and elb naming formats.

```
In [1]: from gogoutils import Generator

In [2]: g = Generator('mygroup', 'special-repo')

In [3]: g.security_group_app
Out[3]: 'special-repomygroup'

In [4]: g.elb_app
Out[4]: 'special-repomygroup'
```